### PR TITLE
Feature/bitnuke inclusive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 stage.tmp/
 deps/bitnuke
 *.aci
+*.swp

--- a/bitnuke/dynamic_handler.go
+++ b/bitnuke/dynamic_handler.go
@@ -81,7 +81,7 @@ func handlerdynamic(w http.ResponseWriter, r *http.Request, redisClient *redis.C
 
 		// dont add the filename header to links
 		if string(filename) != "bitnuke:link" {
-			finalFname := fmt.Sprintf("attachment; filename=%s", filename)
+			finalFname := fmt.Sprintf("INLINE; filename=%s", filename)
 			w.Header().Set("Content-Disposition", finalFname)
 		}
 		http.ServeFile(w, r, "tmpfile")

--- a/deps/Dockerfile.full
+++ b/deps/Dockerfile.full
@@ -1,0 +1,15 @@
+FROM alpine
+
+# pull outside resources
+COPY bitnuke /bin/bitnuke
+COPY nginx /bin/nginx
+COPY redis-server /bin/redis-server
+COPY config.gcfg /
+COPY redis.conf /
+COPY run_all.sh /run_all.sh
+
+# stage directories
+RUN mkdir -p /nginx/log/
+RUN mkdir -p /redisbackup/
+
+CMD ["/run_all.sh"]

--- a/deps/run_all.sh
+++ b/deps/run_all.sh
@@ -1,0 +1,10 @@
+#!/bin/ash
+
+# start redis server
+redis-server /redis.conf | sed "s/^/[redis] /" &
+
+# start bitnuke
+bitnuke | sed "s/^/[bitnuke] /" &
+
+# start nginx
+nginx | sed "s/^/[nginx] /"

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This repo is strictly the API that supports the following REST calls:
 
 
 ## Running Bitnuke
-There are 2 ways to run bitnuke:
+There are 3 ways to run bitnuke:
 
 1. **From Source**: Redis and Nginx are required to be run before the code can be run.
 Nginx configs can be found in `deps/conf/` and the static files for the frontend are
@@ -20,7 +20,10 @@ If you want to compile the code use:
 [here](https://cryo.unixvoid.com/bin/rkt/bitnuke-api/) or go give us a fetch for 64bit machines!
 `rkt fetch unixvoid.com/bitnuke-api:0.20.2`.  This image can be run with rkt or you can
 grab our handy service file at `deps/bitnuke.service`
-
+3. **Docker-compose**: If you want to run the full docker stack (complete with ui and
+redis) you can build the images and then run from the current directory.  
+`make build-full`  
+`make run-full`  
 
 ## API guide
 Bitnuke uses an API for all actions that take place on the site, the following is the


### PR DESCRIPTION
This PR brings in a docker image that contains all bitnukes elements in one container.

This put redis, nginx, and bitnuke all in one easy to deploy container.

- `make build-full` added to create new all-inclusive image
- `make run-full` added to easily run the container locally with no setup.

This is good for end-to-end testing of the platform especially if changing nginx configs.